### PR TITLE
Fixed authenticate screen

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/ui/transactions/BaseTransactionActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/transactions/BaseTransactionActivity.kt
@@ -1,6 +1,7 @@
 package pm.gnosis.heimdall.ui.transactions
 
 import android.os.Bundle
+import android.support.design.widget.Snackbar
 import android.view.View
 import com.gojuno.koptional.Optional
 import com.jakewharton.rxbinding2.view.clicks
@@ -79,7 +80,7 @@ abstract class BaseTransactionActivity : BaseActivity() {
                                     .toObservable()
                         }
                     } ?: Observable.empty<Result<Unit>>()
-                }.subscribeForResult({ finish() }, ::showErrorSnackbar)
+                }.subscribeForResult({ finish() }, { showErrorSnackbar(it) })
 
         val fragment = supportFragmentManager.findFragmentById(R.id.layout_transaction_details_transaction_container)
         if (fragment is BaseTransactionDetailsFragment) {
@@ -150,14 +151,14 @@ abstract class BaseTransactionActivity : BaseActivity() {
 
     private fun handleInfoError(throwable: Throwable) {
         Timber.e(throwable)
-        showErrorSnackbar(throwable)
+        showErrorSnackbar(throwable, Snackbar.LENGTH_INDEFINITE)
     }
 
-    private fun showErrorSnackbar(throwable: Throwable) {
+    private fun showErrorSnackbar(throwable: Throwable, duration: Int = Snackbar.LENGTH_LONG) {
         // We don't want to show a snackbar if no safe is selected (UI should have been updated accordingly)
         if (throwable is NoSafeSelectedException) return
         if (throwable !is TransactionInputException || throwable.showSnackbar) {
-            errorSnackbar(layout_transaction_details_transaction_container, throwable)
+            errorSnackbar(layout_transaction_details_transaction_container, throwable, duration)
         }
     }
 

--- a/app/src/main/java/pm/gnosis/heimdall/utils/AppUtils.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/utils/AppUtils.kt
@@ -2,15 +2,16 @@ package pm.gnosis.heimdall.utils
 
 import android.app.Activity
 import android.content.Intent
+import android.support.design.widget.Snackbar
 import android.view.View
 import pm.gnosis.heimdall.R
 import pm.gnosis.heimdall.common.utils.ZxingIntentIntegrator
 import pm.gnosis.heimdall.common.utils.snackbar
 import pm.gnosis.heimdall.ui.exceptions.LocalizedException
 
-fun errorSnackbar(view: View, throwable: Throwable) {
+fun errorSnackbar(view: View, throwable: Throwable, duration: Int = Snackbar.LENGTH_LONG) {
     val message = (throwable as? LocalizedException)?.localizedMessage() ?: view.context.getString(R.string.error_try_again)
-    snackbar(view, message)
+    snackbar(view, message, duration)
 }
 
 fun handleQrCodeActivityResult(requestCode: Int, resultCode: Int, data: Intent?,

--- a/app/src/test/java/pm/gnosis/heimdall/ui/authenticate/AuthenticateViewModelTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/authenticate/AuthenticateViewModelTest.kt
@@ -15,6 +15,7 @@ import org.mockito.Mockito.mock
 import org.mockito.junit.MockitoJUnitRunner
 import pm.gnosis.heimdall.GnosisSafe
 import pm.gnosis.heimdall.R
+import pm.gnosis.heimdall.StandardToken
 import pm.gnosis.heimdall.common.utils.DataResult
 import pm.gnosis.heimdall.common.utils.ErrorResult
 import pm.gnosis.heimdall.common.utils.Result
@@ -22,8 +23,10 @@ import pm.gnosis.heimdall.common.utils.ZxingIntentIntegrator
 import pm.gnosis.heimdall.ui.exceptions.SimpleLocalizedException
 import pm.gnosis.heimdall.ui.security.SecurityViewModelTest
 import pm.gnosis.heimdall.utils.ERC67Parser
+import pm.gnosis.model.Solidity
 import pm.gnosis.tests.utils.ImmediateSchedulersRule
 import pm.gnosis.utils.addHexPrefix
+import java.math.BigInteger
 
 @RunWith(MockitoJUnitRunner::class)
 class AuthenticateViewModelTest {
@@ -105,52 +108,8 @@ class AuthenticateViewModelTest {
     }
 
     @Test
-    fun checkResultNoActionData() {
-        val intent = testIntent(createTransactionString())
-        val observer = createObserver()
-
-        viewModel.checkResult(AuthenticateContract.ActivityResults(ZxingIntentIntegrator.REQUEST_CODE, Activity.RESULT_OK, intent))
-                .subscribe(observer)
-
-        then(intent).should().hasExtra(ZxingIntentIntegrator.SCAN_RESULT_EXTRA)
-        then(intent).should().getStringExtra(ZxingIntentIntegrator.SCAN_RESULT_EXTRA)
-        then(intent).shouldHaveNoMoreInteractions()
-        observer.assertComplete().assertNoErrors().assertValue(ErrorResult(SimpleLocalizedException(TEST_STRING)))
-        then(contextMock).should().getString(R.string.unknown_safe_action)
-    }
-
-    @Test
-    fun checkResultUnknownSafeAction() {
-        val intent = testIntent(createTransactionString(data = "TEST_DATA"))
-        val observer = createObserver()
-
-        viewModel.checkResult(AuthenticateContract.ActivityResults(ZxingIntentIntegrator.REQUEST_CODE, Activity.RESULT_OK, intent))
-                .subscribe(observer)
-
-        then(intent).should().hasExtra(ZxingIntentIntegrator.SCAN_RESULT_EXTRA)
-        then(intent).should().getStringExtra(ZxingIntentIntegrator.SCAN_RESULT_EXTRA)
-        then(intent).shouldHaveNoMoreInteractions()
-        observer.assertComplete().assertNoErrors().assertValue(ErrorResult(SimpleLocalizedException(TEST_STRING)))
-        then(contextMock).should().getString(R.string.unknown_safe_action)
-    }
-
-    @Test
-    fun checkResultConfirmAction() {
-        val intent = testIntent(createTransactionString(data = GnosisSafe.ConfirmTransaction.METHOD_ID.addHexPrefix()))
-        val observer = createObserver()
-
-        viewModel.checkResult(AuthenticateContract.ActivityResults(ZxingIntentIntegrator.REQUEST_CODE, Activity.RESULT_OK, intent))
-                .subscribe(observer)
-
-        then(intent).should().hasExtra(ZxingIntentIntegrator.SCAN_RESULT_EXTRA)
-        then(intent).should().getStringExtra(ZxingIntentIntegrator.SCAN_RESULT_EXTRA)
-        then(intent).shouldHaveNoMoreInteractions()
-        observer.assertComplete().assertNoErrors().assertValue { it is DataResult }
-    }
-
-    @Test
-    fun checkResultRevokeAction() {
-        val intent = testIntent(createTransactionString(data = GnosisSafe.RevokeConfirmation.METHOD_ID.addHexPrefix()))
+    fun checkResultTokenTransfer() {
+        val intent = testIntent(createTransactionString(data = StandardToken.Transfer.encode(Solidity.Address(BigInteger.TEN), Solidity.UInt256(BigInteger.ONE))))
         val observer = createObserver()
 
         viewModel.checkResult(AuthenticateContract.ActivityResults(ZxingIntentIntegrator.REQUEST_CODE, Activity.RESULT_OK, intent))


### PR DESCRIPTION
Fixed authenticate screen

Changes proposed in this pull request:
- Use correct layout for error snackbar
- Enable scanning of any transaction
- Fixed handling of returned results from scanner

@gnosis/mobile-devs
