### PR TITLE
WA-101: Load safe info from network before getting it from the view model cache

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/overview/SafeOverviewViewModel.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/overview/SafeOverviewViewModel.kt
@@ -27,9 +27,9 @@ class SafeOverviewViewModel @Inject constructor(
             safeRepository.remove(address)
 
     override fun loadSafeInfo(address: BigInteger): Single<SafeInfo> =
-            infoCache[address]?.let { Single.just(it) } ?:
-                    safeRepository.loadInfo(address).firstOrError()
-                            .doOnSuccess { infoCache.put(address, it) }
+            safeRepository.loadInfo(address).firstOrError()
+                    .doOnSuccess { infoCache.put(address, it) }
+                    .onErrorResumeNext { infoCache[address]?.let { Single.just(it) } ?: Single.error(it)}
 
     override fun observeDeployedStatus(hash: String) =
             safeRepository.observeDeployStatus(hash)


### PR DESCRIPTION
Changes proposed in this pull request:
- Load safe info from network before getting it from the view model cache

@gnosis/mobile-devs
