### PR TITLE
WA-111: Fix security settings visibility on pre Android 6

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/settings/SettingsActivity.kt
@@ -3,7 +3,6 @@ package pm.gnosis.heimdall.ui.settings
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.view.View
 import kotlinx.android.synthetic.main.layout_settings.*
 import pm.gnosis.heimdall.R
 import pm.gnosis.heimdall.reporting.ScreenId
@@ -39,13 +38,8 @@ class SettingsActivity : BaseActivity() {
             startActivity(TokenManagementActivity.createIntent(this))
         }
 
-        // TODO: this check should be done in the SecuritySettingsActivity
-        if (encryptionManager.canSetupFingerprint()) {
-            layout_settings_security.setOnClickListener {
-                startActivity(SecuritySettingsActivity.createIntent(this))
-            }
-        } else {
-            layout_settings_security.visibility = View.GONE
+        layout_settings_security.setOnClickListener {
+            startActivity(SecuritySettingsActivity.createIntent(this))
         }
     }
 

--- a/app/src/main/java/pm/gnosis/heimdall/ui/settings/security/SecuritySettingsActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/settings/security/SecuritySettingsActivity.kt
@@ -3,6 +3,7 @@ package pm.gnosis.heimdall.ui.settings.security
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
 import com.jakewharton.rxbinding2.view.clicks
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.rxkotlin.plusAssign
@@ -41,7 +42,22 @@ class SecuritySettingsActivity : BaseActivity() {
 
     override fun onStart() {
         super.onStart()
-        disposables += layout_security_settings_switch_container.clicks()
+        if (viewModel.isFingerprintAvailable()) setupFingerprintAction()
+
+        disposables += layout_security_settings_show_mnemonic.clicks()
+                .subscribeBy(onNext = {
+                    startActivity(RevealMnemonicActivity.createIntent(this))
+                }, onError = Timber::e)
+
+        disposables += layout_security_settings_change_password.clicks()
+                .subscribeBy(onNext = {
+                    startActivity(ChangePasswordActivity.createIntent(this))
+                }, onError = Timber::e)
+    }
+
+    private fun setupFingerprintAction() {
+        layout_security_settings_fingerprint_switch_container.visibility = View.VISIBLE
+        disposables += layout_security_settings_fingerprint_switch_container.clicks()
                 .subscribeBy(onNext = {
                     if (layout_security_settings_switch.isChecked) {
                         removeFingerprintClick.onNext(Unit)
@@ -64,16 +80,6 @@ class SecuritySettingsActivity : BaseActivity() {
                     layout_security_settings_switch.isChecked = it
                 }, onError = Timber::e)
         getFingerprintStateSubject.onNext(Unit)
-
-        disposables += layout_security_settings_show_mnemonic.clicks()
-                .subscribeBy(onNext = {
-                    startActivity(RevealMnemonicActivity.createIntent(this))
-                }, onError = Timber::e)
-
-        disposables += layout_security_settings_change_password.clicks()
-                .subscribeBy(onNext = {
-                    startActivity(ChangePasswordActivity.createIntent(this))
-                }, onError = Timber::e)
     }
 
     private fun showDialog() {

--- a/app/src/main/java/pm/gnosis/heimdall/ui/settings/security/SecuritySettingsContract.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/settings/security/SecuritySettingsContract.kt
@@ -5,5 +5,6 @@ import io.reactivex.Single
 import pm.gnosis.heimdall.common.utils.Result
 
 abstract class SecuritySettingsContract : ViewModel() {
+    abstract fun isFingerprintAvailable(): Boolean
     abstract fun clearFingerprintData(): Single<Result<Unit>>
 }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/settings/security/SecuritySettingsViewModel.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/settings/security/SecuritySettingsViewModel.kt
@@ -9,6 +9,8 @@ import javax.inject.Inject
 class SecuritySettingsViewModel @Inject constructor(
         private val encryptionManager: EncryptionManager
 ) : SecuritySettingsContract() {
+    override fun isFingerprintAvailable() = encryptionManager.canSetupFingerprint()
+
     override fun clearFingerprintData(): Single<Result<Unit>> =
             encryptionManager.clearFingerprintData()
                     .andThen(Single.just(Unit))

--- a/app/src/main/res/layout/layout_security_settings.xml
+++ b/app/src/main/res/layout/layout_security_settings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/layout_security_settings_coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -21,13 +22,15 @@
                 android:orientation="vertical">
 
                 <LinearLayout
-                    android:id="@+id/layout_security_settings_switch_container"
+                    android:id="@+id/layout_security_settings_fingerprint_switch_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:background="@drawable/selectable_background"
                     android:gravity="center_vertical"
                     android:orientation="horizontal"
-                    android:padding="16dp">
+                    android:padding="16dp"
+                    android:visibility="gone"
+                    tools:visibility="visible">
 
                     <TextView
                         android:layout_width="0dp"

--- a/app/src/test/java/pm/gnosis/heimdall/ui/settings/security/SecuritySettingsViewModelTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/ui/settings/security/SecuritySettingsViewModelTest.kt
@@ -1,0 +1,84 @@
+package pm.gnosis.heimdall.ui.settings.security
+
+import io.reactivex.Completable
+import io.reactivex.observers.TestObserver
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.then
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import pm.gnosis.heimdall.common.utils.DataResult
+import pm.gnosis.heimdall.common.utils.ErrorResult
+import pm.gnosis.heimdall.common.utils.Result
+import pm.gnosis.heimdall.security.EncryptionManager
+import pm.gnosis.tests.utils.ImmediateSchedulersRule
+import pm.gnosis.tests.utils.TestCompletable
+
+@RunWith(MockitoJUnitRunner::class)
+class SecuritySettingsViewModelTest {
+    @JvmField
+    @Rule
+    val rule = ImmediateSchedulersRule()
+
+    @Mock
+    private lateinit var encryptionManagerMock: EncryptionManager
+
+    private lateinit var viewModel: SecuritySettingsViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = SecuritySettingsViewModel(encryptionManagerMock)
+    }
+
+    @Test
+    fun fingerprintAvailable() {
+        given(encryptionManagerMock.canSetupFingerprint()).willReturn(true)
+
+        val result = viewModel.isFingerprintAvailable()
+
+        then(encryptionManagerMock).should().canSetupFingerprint()
+        then(encryptionManagerMock).shouldHaveNoMoreInteractions()
+        assertEquals(result, true)
+    }
+
+    @Test
+    fun fingerprintNotAvailable() {
+        given(encryptionManagerMock.canSetupFingerprint()).willReturn(false)
+
+        val result = viewModel.isFingerprintAvailable()
+
+        then(encryptionManagerMock).should().canSetupFingerprint()
+        then(encryptionManagerMock).shouldHaveNoMoreInteractions()
+        assertEquals(result, false)
+    }
+
+    @Test
+    fun clearFingerprintData() {
+        val testCompletable = TestCompletable()
+        val testObserver = TestObserver<Result<Unit>>()
+        given(encryptionManagerMock.clearFingerprintData()).willReturn(testCompletable)
+
+        viewModel.clearFingerprintData().subscribe(testObserver)
+
+        then(encryptionManagerMock).should().clearFingerprintData()
+        then(encryptionManagerMock).shouldHaveNoMoreInteractions()
+        testObserver.assertResult(DataResult(Unit))
+    }
+
+    @Test
+    fun clearFingerprintDataError() {
+        val exception = Exception()
+        val testObserver = TestObserver<Result<Unit>>()
+        given(encryptionManagerMock.clearFingerprintData()).willReturn(Completable.error(exception))
+
+        viewModel.clearFingerprintData().subscribe(testObserver)
+
+        then(encryptionManagerMock).should().clearFingerprintData()
+        then(encryptionManagerMock).shouldHaveNoMoreInteractions()
+        testObserver.assertResult(ErrorResult(exception))
+    }
+}

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
             android_tools          : '3.0.1',
             fabric                 : '1.+',
             google_services        : '3.1.0',
-            kotlin                 : '1.2.20',
+            kotlin                 : '1.2.21',
             jacoco                 : '0.7.9',
 
             // Runtime dependencies


### PR DESCRIPTION
Changes proposed in this pull request:
- Show Security Settings on every version
- Hide the Fingerprint section in Security Settings 

@gnosis/mobile-devs
