### PR TITLE
WA-133: Adjust request signature flow

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ android {
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
 
-        project.ext.set("archivesBaseName", String.format("gnosis-authenticator-%s", defaultConfig.versionCode))
+        project.ext.set("archivesBaseName", String.format("gnosis-safe-%s", defaultConfig.versionCode))
 
         ext.betaDistributionGroupAliases = System.getenv("FABRIC_GROUP_INTERNAL_BETA")
         ext.betaDistributionReleaseNotes = System.getenv("APP_RELEASE_NOTES")

--- a/app/schemas/pm.gnosis.heimdall.data.db.ApplicationDb/1.json
+++ b/app/schemas/pm.gnosis.heimdall.data.db.ApplicationDb/1.json
@@ -1,0 +1,247 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "81f54c59bce18543e3950f4c0b050eaa",
+    "entities": [
+      {
+        "tableName": "address_book",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`address` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, PRIMARY KEY(`address`))",
+        "fields": [
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "address"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "erc20_tokens",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`address` TEXT NOT NULL, `name` TEXT, `symbol` TEXT, `decimals` INTEGER NOT NULL, `verified` INTEGER NOT NULL, PRIMARY KEY(`address`))",
+        "fields": [
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "decimals",
+            "columnName": "decimals",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "verified",
+            "columnName": "verified",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "address"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "gnosis_safes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`address` TEXT NOT NULL, `name` TEXT, PRIMARY KEY(`address`))",
+        "fields": [
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "address"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "gnosis_pending_safes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transactionHash` TEXT NOT NULL, `name` TEXT, PRIMARY KEY(`transactionHash`))",
+        "fields": [
+          {
+            "fieldPath": "transactionHash",
+            "columnName": "transactionHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "transactionHash"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "transaction_details",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `safeAddress` TEXT NOT NULL, `to` TEXT NOT NULL, `value` TEXT NOT NULL, `data` TEXT NOT NULL, `operation` TEXT NOT NULL, `nonce` TEXT NOT NULL, `submittedAt` INTEGER NOT NULL, `subject` TEXT, `txHash` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "safeAddress",
+            "columnName": "safeAddress",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "to",
+            "columnName": "to",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operation",
+            "columnName": "operation",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nonce",
+            "columnName": "nonce",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subject",
+            "columnName": "subject",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "transactionHash",
+            "columnName": "txHash",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "transaction_publish_status",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `transactionId` TEXT NOT NULL, `success` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transactionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "success",
+            "columnName": "success",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"81f54c59bce18543e3950f4c0b050eaa\")"
+    ]
+  }
+}

--- a/app/src/main/java/pm/gnosis/heimdall/common/di/modules/ApplicationModule.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/common/di/modules/ApplicationModule.kt
@@ -11,7 +11,7 @@ import okhttp3.OkHttpClient
 import pm.gnosis.heimdall.common.di.ApplicationContext
 import pm.gnosis.heimdall.data.adapters.HexNumberAdapter
 import pm.gnosis.heimdall.data.adapters.WeiAdapter
-import pm.gnosis.heimdall.data.db.GnosisAuthenticatorDb
+import pm.gnosis.heimdall.data.db.ApplicationDb
 import pm.gnosis.heimdall.data.remote.EthGasStationApi
 import pm.gnosis.heimdall.data.remote.EthereumJsonRpcApi
 import pm.gnosis.heimdall.data.remote.IpfsApi
@@ -112,6 +112,6 @@ class ApplicationModule {
     @Provides
     @Singleton
     fun providesDb(@ApplicationContext context: Context) =
-            Room.databaseBuilder(context, GnosisAuthenticatorDb::class.java, GnosisAuthenticatorDb.DB_NAME)
+            Room.databaseBuilder(context, ApplicationDb::class.java, ApplicationDb.DB_NAME)
                     .build()
 }

--- a/app/src/main/java/pm/gnosis/heimdall/data/db/ApplicationDb.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/db/ApplicationDb.kt
@@ -18,9 +18,9 @@ import pm.gnosis.heimdall.data.db.models.*
     TransactionPublishStatusDb::class
 ], version = 1)
 @TypeConverters(BigIntegerConverter::class)
-abstract class GnosisAuthenticatorDb : RoomDatabase() {
+abstract class ApplicationDb : RoomDatabase() {
     companion object {
-        const val DB_NAME = "gnosis-authenticator-db"
+        const val DB_NAME = "gnosis-safe-db"
     }
 
     abstract fun addressBookDao(): AddressBookDao

--- a/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/DefaultAddressBookRepository.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/DefaultAddressBookRepository.kt
@@ -3,7 +3,7 @@ package pm.gnosis.heimdall.data.repositories.impls
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.schedulers.Schedulers
-import pm.gnosis.heimdall.data.db.GnosisAuthenticatorDb
+import pm.gnosis.heimdall.data.db.ApplicationDb
 import pm.gnosis.heimdall.data.db.models.AddressBookEntryDb
 import pm.gnosis.heimdall.data.db.models.fromDB
 import pm.gnosis.heimdall.data.repositories.AddressBookRepository
@@ -14,10 +14,10 @@ import javax.inject.Singleton
 
 @Singleton
 class DefaultAddressBookRepository @Inject constructor(
-        gnosisAuthenticatorDb: GnosisAuthenticatorDb
+        appDb: ApplicationDb
 ) : AddressBookRepository {
 
-    private val addressBookDao = gnosisAuthenticatorDb.addressBookDao()
+    private val addressBookDao = appDb.addressBookDao()
 
     override fun addAddressBookEntry(address: BigInteger, name: String, description: String): Completable =
             Completable.fromCallable {

--- a/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/DefaultGnosisSafeRepository.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/DefaultGnosisSafeRepository.kt
@@ -12,7 +12,7 @@ import pm.gnosis.heimdall.GnosisSafe.Threshold
 import pm.gnosis.heimdall.ProxyFactory
 import pm.gnosis.heimdall.accounts.base.models.Account
 import pm.gnosis.heimdall.accounts.base.repositories.AccountsRepository
-import pm.gnosis.heimdall.data.db.GnosisAuthenticatorDb
+import pm.gnosis.heimdall.data.db.ApplicationDb
 import pm.gnosis.heimdall.data.db.models.GnosisSafeDb
 import pm.gnosis.heimdall.data.db.models.PendingGnosisSafeDb
 import pm.gnosis.heimdall.data.db.models.fromDb
@@ -43,7 +43,7 @@ import javax.inject.Singleton
 
 @Singleton
 class DefaultGnosisSafeRepository @Inject constructor(
-        gnosisAuthenticatorDb: GnosisAuthenticatorDb,
+        gnosisAuthenticatorDb: ApplicationDb,
         private val accountsRepository: AccountsRepository,
         private val ethereumJsonRpcRepository: EthereumJsonRpcRepository,
         private val settingsRepository: SettingsRepository

--- a/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/DefaultTokenRepository.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/DefaultTokenRepository.kt
@@ -15,7 +15,7 @@ import pm.gnosis.heimdall.common.PreferencesManager
 import pm.gnosis.heimdall.common.di.ApplicationContext
 import pm.gnosis.heimdall.common.utils.ERC20
 import pm.gnosis.heimdall.common.utils.edit
-import pm.gnosis.heimdall.data.db.GnosisAuthenticatorDb
+import pm.gnosis.heimdall.data.db.ApplicationDb
 import pm.gnosis.heimdall.data.db.models.ERC20TokenDb
 import pm.gnosis.heimdall.data.remote.BulkRequest
 import pm.gnosis.heimdall.data.remote.EthereumJsonRpcRepository
@@ -35,13 +35,13 @@ import javax.inject.Singleton
 
 @Singleton
 class DefaultTokenRepository @Inject constructor(
-        gnosisAuthenticatorDb: GnosisAuthenticatorDb,
+        appDb: ApplicationDb,
         private val ethereumJsonRpcRepository: EthereumJsonRpcRepository,
         private val preferencesManager: PreferencesManager,
         private val moshi: Moshi,
         @ApplicationContext private val context: Context
 ) : TokenRepository {
-    private val erc20TokenDao = gnosisAuthenticatorDb.erc20TokenDao()
+    private val erc20TokenDao = appDb.erc20TokenDao()
 
     override fun observeTokens(): Flowable<List<ERC20Token>> =
             erc20TokenDao.observeTokens()

--- a/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/GnosisSafeTransactionRepository.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/GnosisSafeTransactionRepository.kt
@@ -8,7 +8,7 @@ import pm.gnosis.crypto.utils.Sha3Utils
 import pm.gnosis.heimdall.GnosisSafe
 import pm.gnosis.heimdall.accounts.base.models.Signature
 import pm.gnosis.heimdall.accounts.base.repositories.AccountsRepository
-import pm.gnosis.heimdall.data.db.GnosisAuthenticatorDb
+import pm.gnosis.heimdall.data.db.ApplicationDb
 import pm.gnosis.heimdall.data.db.models.TransactionDescriptionDb
 import pm.gnosis.heimdall.data.db.models.TransactionPublishStatusDb
 import pm.gnosis.heimdall.data.remote.BulkRequest
@@ -30,12 +30,12 @@ import javax.inject.Singleton
 
 @Singleton
 class GnosisSafeTransactionRepository @Inject constructor(
-        authenticatorDb: GnosisAuthenticatorDb,
+        appDb: ApplicationDb,
         private val accountsRepository: AccountsRepository,
         private val ethereumJsonRpcRepository: EthereumJsonRpcRepository
 ) : TransactionRepository {
 
-    private val descriptionsDao = authenticatorDb.descriptionsDao()
+    private val descriptionsDao = appDb.descriptionsDao()
 
     override fun calculateHash(safeAddress: BigInteger, transaction: Transaction): Single<ByteArray> =
             Single.fromCallable {

--- a/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/SimpleTransactionDetailsRepository.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/data/repositories/impls/SimpleTransactionDetailsRepository.kt
@@ -6,7 +6,7 @@ import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
 import pm.gnosis.heimdall.GnosisSafe
 import pm.gnosis.heimdall.StandardToken
-import pm.gnosis.heimdall.data.db.GnosisAuthenticatorDb
+import pm.gnosis.heimdall.data.db.ApplicationDb
 import pm.gnosis.heimdall.data.db.models.fromDb
 import pm.gnosis.heimdall.data.remote.models.GnosisSafeTransactionDescription
 import pm.gnosis.heimdall.data.repositories.*
@@ -19,10 +19,10 @@ import javax.inject.Singleton
 
 @Singleton
 class SimpleTransactionDetailsRepository @Inject constructor(
-        authenticatorDb: GnosisAuthenticatorDb
+        appDb: ApplicationDb
 ) : TransactionDetailsRepository {
 
-    private val descriptionsDao = authenticatorDb.descriptionsDao()
+    private val descriptionsDao = appDb.descriptionsDao()
 
     override fun loadTransactionData(transaction: Transaction): Single<Optional<TransactionTypeData>> {
         return Single.fromCallable {

--- a/app/src/main/java/pm/gnosis/heimdall/ui/dialogs/share/RequestSignatureDialog.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/dialogs/share/RequestSignatureDialog.kt
@@ -7,33 +7,25 @@ import android.view.View
 import android.view.ViewGroup
 import com.jakewharton.rxbinding2.view.clicks
 import io.reactivex.Observable
-import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.rxkotlin.plusAssign
 import kotlinx.android.synthetic.main.dialog_request_signature.*
 import pm.gnosis.heimdall.HeimdallApplication
 import pm.gnosis.heimdall.R
 import pm.gnosis.heimdall.common.di.components.DaggerViewComponent
 import pm.gnosis.heimdall.common.di.modules.ViewModule
-import pm.gnosis.heimdall.common.utils.mapToResult
 import pm.gnosis.heimdall.common.utils.scanQrCode
-import pm.gnosis.heimdall.common.utils.subscribeForResult
 import pm.gnosis.heimdall.common.utils.toast
 import pm.gnosis.heimdall.data.repositories.SignaturePushRepository
 import pm.gnosis.heimdall.reporting.ScreenId
 import pm.gnosis.heimdall.utils.GnoSafeUrlParser
-import pm.gnosis.heimdall.utils.errorSnackbar
 import pm.gnosis.models.Transaction
 import pm.gnosis.models.TransactionParcelable
 import pm.gnosis.utils.asEthereumAddressString
 import pm.gnosis.utils.hexAsEthereumAddressOrNull
-import timber.log.Timber
 import java.math.BigInteger
 import javax.inject.Inject
 
 class RequestSignatureDialog : BaseShareQrCodeDialog() {
-
-    @Inject
-    lateinit var signaturePushRepository: SignaturePushRepository
 
     private lateinit var transactionHash: String
     private lateinit var transaction: Transaction
@@ -86,19 +78,6 @@ class RequestSignatureDialog : BaseShareQrCodeDialog() {
                     activity?.scanQrCode()
                     dismiss()
                 }
-        disposables += dialog_request_signature_push.clicks()
-                .flatMapSingle {
-                    signaturePushRepository.request(safe, data())
-                            .mapToResult()
-                }
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribeForResult({
-                    context!!.toast(R.string.signature_request_sent)
-                    dismiss()
-                }, {
-                    Timber.e(it)
-                    errorSnackbar(dialog_request_signature_push, it)
-                })
     }
 
     override fun onCopiedToClipboard() {

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/add/DeployNewSafeFragment.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/add/DeployNewSafeFragment.kt
@@ -61,9 +61,7 @@ class DeployNewSafeFragment : BaseFragment() {
                 .observeOn(AndroidSchedulers.mainThread())
                 .doOnNextForResult(::updateEstimate)
                 // Request fiat value for price
-                .flatMapSingle {
-                    it.mapSingle({ viewModel.loadFiatConversion(it) })
-                }
+                .flatMapResult({ viewModel.loadFiatConversion(it) })
                 // Update fiat value
                 .observeOn(AndroidSchedulers.mainThread())
                 .doOnNextForResult(::onFiat, ::onFiatError)

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/details/SafeDetailsActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/details/SafeDetailsActivity.kt
@@ -19,6 +19,7 @@ import pm.gnosis.heimdall.reporting.ButtonId
 import pm.gnosis.heimdall.reporting.Event
 import pm.gnosis.heimdall.reporting.ScreenId
 import pm.gnosis.heimdall.reporting.TabId
+import pm.gnosis.heimdall.ui.authenticate.AuthenticateActivity
 import pm.gnosis.heimdall.ui.base.BaseActivity
 import pm.gnosis.heimdall.ui.base.FactoryPagerAdapter
 import pm.gnosis.heimdall.ui.dialogs.share.ShareSafeAddressDialog
@@ -65,7 +66,7 @@ class SafeDetailsActivity : BaseActivity() {
 
         layout_safe_details_fab.setOnClickListener {
             eventTracker.submit(Event.ButtonClick(ButtonId.SAFE_DETAILS_CREATE_TRANSACTION))
-            startActivity(CreateTransactionActivity.createIntent(this, safeAddress.hexAsBigIntegerOrNull(), TransactionType.TOKEN_TRANSFER, null))
+            startActivity(AuthenticateActivity.createIntent(this))
         }
         layout_safe_details_viewpager.adapter = pagerAdapter()
         layout_safe_details_tabbar.setupWithViewPager(layout_safe_details_viewpager)

--- a/app/src/main/java/pm/gnosis/heimdall/ui/safe/overview/SafesOverviewActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/safe/overview/SafesOverviewActivity.kt
@@ -16,6 +16,7 @@ import pm.gnosis.heimdall.R
 import pm.gnosis.heimdall.common.di.components.DaggerViewComponent
 import pm.gnosis.heimdall.common.di.modules.ViewModule
 import pm.gnosis.heimdall.common.utils.subscribeForResult
+import pm.gnosis.heimdall.common.utils.visible
 import pm.gnosis.heimdall.data.repositories.models.AbstractSafe
 import pm.gnosis.heimdall.data.repositories.models.Safe
 import pm.gnosis.heimdall.reporting.ButtonId
@@ -103,7 +104,7 @@ class SafesOverviewActivity : BaseActivity() {
 
     private fun onSafes(data: Adapter.Data<AbstractSafe>) {
         adapter.updateData(data)
-        layout_safe_overview_empty_view.visibility = if (data.entries.isEmpty()) View.VISIBLE else View.GONE
+        layout_safe_overview_empty_view.visible(data.entries.isEmpty())
     }
 
     private fun onSafesError(throwable: Throwable) {

--- a/app/src/main/java/pm/gnosis/heimdall/ui/transactions/SignTransactionActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/transactions/SignTransactionActivity.kt
@@ -16,10 +16,7 @@ import pm.gnosis.heimdall.HeimdallApplication
 import pm.gnosis.heimdall.R
 import pm.gnosis.heimdall.common.di.components.DaggerViewComponent
 import pm.gnosis.heimdall.common.di.modules.ViewModule
-import pm.gnosis.heimdall.common.utils.DataResult
-import pm.gnosis.heimdall.common.utils.Result
-import pm.gnosis.heimdall.common.utils.snackbar
-import pm.gnosis.heimdall.common.utils.subscribeForResult
+import pm.gnosis.heimdall.common.utils.*
 import pm.gnosis.heimdall.reporting.Event
 import pm.gnosis.heimdall.reporting.ScreenId
 import pm.gnosis.heimdall.ui.security.unlock.UnlockActivity
@@ -106,7 +103,7 @@ class SignTransactionActivity : ViewTransactionActivity() {
                     .toObservable()
 
     private fun signingTransaction(loading: Boolean) {
-        layout_sign_transaction_progress_bar.visibility = if (loading) View.VISIBLE else View.GONE
+        layout_sign_transaction_progress_bar.visible(loading)
         layout_sign_transaction_sign_button.isEnabled = !loading
         transactionInputEnabled(!loading)
     }

--- a/app/src/main/java/pm/gnosis/heimdall/ui/transactions/ViewTransactionContract.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/transactions/ViewTransactionContract.kt
@@ -20,7 +20,8 @@ abstract class ViewTransactionContract : ViewModel() {
     abstract fun loadExecuteInfo(safeAddress: BigInteger, transaction: Transaction): Observable<Result<Info>>
     abstract fun submitTransaction(safeAddress: BigInteger, transaction: Transaction, overrideGasPrice: Wei?): Single<Result<BigInteger>>
     abstract fun signTransaction(safeAddress: BigInteger, transaction: Transaction, sendViaPush: Boolean = false): Single<Result<Pair<String, Bitmap?>>>
-    abstract fun observePushSignature(safeAddress: BigInteger, transaction: Transaction): Observable<Result<Unit>>
+    abstract fun observeSignaturePushes(safeAddress: BigInteger, transaction: Transaction): Observable<Result<Unit>>
+    abstract fun sendSignaturePush(info: Info): Single<Result<Unit>>
     abstract fun addSignature(encodedSignatureUrl: String): Completable
 
     data class Info(val selectedSafe: BigInteger, val status: TransactionRepository.ExecuteInformation, val signatures: Map<BigInteger, Signature>, val estimate: GasEstimate? = null)

--- a/app/src/main/res/layout/dialog_request_signature.xml
+++ b/app/src/main/res/layout/dialog_request_signature.xml
@@ -10,24 +10,6 @@
 
     <include layout="@layout/include_base_share_qr_code" />
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/white"
-        android:gravity="center"
-        android:paddingBottom="8dp">
-
-        <TextView
-            android:id="@+id/dialog_request_signature_push"
-            style="@style/TextButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center"
-            android:padding="8dp"
-            android:text="Request via push" />
-    </LinearLayout>
-
     <TextView
         android:id="@+id/dialog_request_signature_scan"
         style="@style/PrimaryButton.FullWidth"

--- a/app/src/main/res/layout/layout_create_add_safe_owner.xml
+++ b/app/src/main/res/layout/layout_create_add_safe_owner.xml
@@ -31,11 +31,19 @@
             style="@style/Content"
             android:layout_width="@dimen/create_tx_label_width"
             android:layout_height="wrap_content"
-            android:paddingLeft="16dp"
             android:paddingStart="16dp"
             android:text="@string/safe" />
 
-        <include layout="@layout/layout_create_transaction_safe_info" />
+
+        <TextView
+            android:id="@+id/layout_create_add_safe_owner_safe_address"
+            style="@style/BoldContent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:gravity="start"
+            android:maxLines="2"
+            tools:text="My Safe [0x9bea...eda2]" />
     </LinearLayout>
 
     <View
@@ -52,10 +60,8 @@
             style="@style/Content"
             android:layout_width="@dimen/create_tx_label_width"
             android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"
             android:layout_centerVertical="true"
-            android:paddingLeft="16dp"
             android:paddingStart="16dp"
             android:text="@string/new_owner" />
 
@@ -64,7 +70,6 @@
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
             android:layout_centerVertical="true"
             android:layout_gravity="end"
             android:background="@drawable/selectable_background"
@@ -78,7 +83,6 @@
             android:layout_width="@dimen/divider_width"
             android:layout_height="match_parent"
             android:layout_alignWithParentIfMissing="true"
-            android:layout_toLeftOf="@+id/layout_create_add_safe_owner_scan_address_button"
             android:layout_toStartOf="@+id/layout_create_add_safe_owner_scan_address_button"
             android:background="@color/divider" />
 
@@ -90,7 +94,6 @@
             android:layout_alignWithParentIfMissing="true"
             android:layout_gravity="bottom"
             android:layout_toEndOf="@id/layout_create_add_safe_owner_address_label"
-            android:layout_toLeftOf="@id/layout_create_add_safe_owner_divider_qr_code"
             android:layout_toRightOf="@id/layout_create_add_safe_owner_address_label"
             android:layout_toStartOf="@id/layout_create_add_safe_owner_divider_qr_code"
             android:hint="@string/address_hint"

--- a/app/src/main/res/layout/layout_pending_safe_item.xml
+++ b/app/src/main/res/layout/layout_pending_safe_item.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@color/text_grey_background"
     android:gravity="center_vertical"
     android:padding="16dp">
@@ -12,7 +13,7 @@
         android:layout_height="@dimen/action_circle"
         android:background="@drawable/progress_circle_background"
         android:padding="8dp"
-        android:theme="@style/WhiteCircleProgress" />
+        app:mpb_indeterminateTint="@color/white" />
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/layout_submit_transaction.xml
+++ b/app/src/main/res/layout/layout_submit_transaction.xml
@@ -127,16 +127,45 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical" />
 
-            <TextView
-                android:id="@+id/layout_submit_transaction_add_signature_button"
+            <LinearLayout
+                android:id="@+id/layout_submit_transaction_send_signature_push_button"
                 style="@style/PrimaryButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_margin="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
                 android:layout_marginTop="16dp"
-                android:text="@string/add_signature"
-                tools:visibility="gone" />
+                tools:visibility="visible">
+
+                <TextView
+                    style="@style/PrimaryButtonText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="@string/push_signature_request" />
+
+                <me.zhanghai.android.materialprogressbar.MaterialProgressBar
+                    android:id="@+id/layout_submit_transaction_send_signature_push_progress"
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginStart="8dp"
+                    android:visibility="gone"
+                    app:mpb_indeterminateTint="@color/white" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/layout_submit_transaction_scan_signature_qr_button"
+                style="@style/SecondaryTextButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginTop="8dp"
+                android:gravity="center"
+                android:text="@string/scan_signature_qr"
+                tools:visibility="visible" />
 
             <TextView
                 android:id="@+id/layout_submit_transaction_all_confirmed_hint"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Gnosis Authenticator</string>
+    <string name="app_name">Gnosis Safe</string>
     <string name="scan_instructions">
         <b>1.</b> Generate a Confirm/Revoke transaction QRCode (following the ERC67 scheme)\n<b>2.</b> Scan the transaction and verify the fields before confirming/revoking it\n\n<b>Reminder:</b> The account of this application (found in the account section) must be one of the owners of the Safe. The number of confirmations should be adjusted accordingly.
     </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,7 +85,7 @@
         <item quantity="other">%s Confirmations</item>
     </plurals>
     <string name="submit_transaction">Submit Transaction</string>
-    <string name="add_signature">Add signature</string>
+    <string name="scan_signature_qr">Manually scan signature QR</string>
     <string name="cancel">Cancel</string>
     <string name="invalid_ethereum_address">Invalid ethereum address</string>
     <string name="added_safe">Safe Added</string>
@@ -306,4 +306,5 @@
     <string name="low_balance_warning">No sufficient balance in your account to deploy a new safe. Send %1s ETH to your account address.</string>
     <string name="dismiss">Dismiss</string>
     <string name="view_account">View Account</string>
+    <string name="push_signature_request">Push Signature Request</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -74,9 +74,7 @@
     <style name="PrimaryButtonText">
         <item name="android:textColor">@color/white</item>
         <item name="android:textSize">@dimen/primary_button_text_size</item>
-        <item name="android:textAllCaps">true</item>
         <item name="android:gravity">center</item>
-        <item name="android:textStyle">bold</item>
     </style>
 
     <style name="PrimaryButton">
@@ -127,6 +125,10 @@
         <item name="android:paddingBottom">8dp</item>
         <item name="android:paddingLeft">16dp</item>
         <item name="android:paddingRight">16dp</item>
+    </style>
+
+    <style name="SecondaryTextButton" parent="TextButton">
+        <item name="android:textColor">@color/secondary_button_text</item>
     </style>
 
     <!-- End: Button styles -->
@@ -226,8 +228,4 @@
     </style>
 
     <!-- End: Text styles -->
-
-    <style name="WhiteCircleProgress" parent="Theme.AppCompat.Light">
-        <item name="colorAccent">@color/white</item>
-    </style>
 </resources>

--- a/app/src/test/java/pm/gnosis/heimdall/data/repositories/impls/DefaultTokenRepositoryTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/data/repositories/impls/DefaultTokenRepositoryTest.kt
@@ -29,7 +29,7 @@ import pm.gnosis.heimdall.common.utils.DataResult
 import pm.gnosis.heimdall.common.utils.ERC20
 import pm.gnosis.heimdall.common.utils.ErrorResult
 import pm.gnosis.heimdall.common.utils.Result
-import pm.gnosis.heimdall.data.db.GnosisAuthenticatorDb
+import pm.gnosis.heimdall.data.db.ApplicationDb
 import pm.gnosis.heimdall.data.db.daos.ERC20TokenDao
 import pm.gnosis.heimdall.data.db.models.ERC20TokenDb
 import pm.gnosis.heimdall.data.remote.*
@@ -58,7 +58,7 @@ class DefaultTokenRepositoryTest {
     private lateinit var application: Application
 
     @Mock
-    lateinit var dbMock: GnosisAuthenticatorDb
+    lateinit var dbMock: ApplicationDb
 
     @Mock
     lateinit var erc20DaoMock: ERC20TokenDao

--- a/app/src/test/java/pm/gnosis/heimdall/data/repositories/impls/GnosisSafeTransactionRepositoryTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/data/repositories/impls/GnosisSafeTransactionRepositoryTest.kt
@@ -11,7 +11,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import pm.gnosis.heimdall.StandardToken
 import pm.gnosis.heimdall.accounts.base.repositories.AccountsRepository
-import pm.gnosis.heimdall.data.db.GnosisAuthenticatorDb
+import pm.gnosis.heimdall.data.db.ApplicationDb
 import pm.gnosis.heimdall.data.db.daos.DescriptionsDao
 import pm.gnosis.heimdall.data.remote.EthereumJsonRpcRepository
 import pm.gnosis.model.Solidity
@@ -38,14 +38,14 @@ class GnosisSafeTransactionRepositoryTest {
     lateinit var descriptionsDaoMock: DescriptionsDao
 
     @Mock
-    lateinit var gnosisAuthenticatorDbMock: GnosisAuthenticatorDb
+    lateinit var appDbMock: ApplicationDb
 
     private lateinit var repository: GnosisSafeTransactionRepository
 
     @Before
     fun setUp() {
-        given(gnosisAuthenticatorDbMock.descriptionsDao()).willReturn(descriptionsDaoMock)
-        repository = GnosisSafeTransactionRepository(gnosisAuthenticatorDbMock, accountRepositoryMock, ethereumJsonRpcRepositoryMock)
+        given(appDbMock.descriptionsDao()).willReturn(descriptionsDaoMock)
+        repository = GnosisSafeTransactionRepository(appDbMock, accountRepositoryMock, ethereumJsonRpcRepositoryMock)
     }
 
     private fun verifyHash(safe: BigInteger, transaction: Transaction, expected: String) {

--- a/app/src/test/java/pm/gnosis/heimdall/data/repositories/impls/SimpleTransactionDetailsRepositoryTest.kt
+++ b/app/src/test/java/pm/gnosis/heimdall/data/repositories/impls/SimpleTransactionDetailsRepositoryTest.kt
@@ -10,7 +10,7 @@ import org.mockito.BDDMockito.then
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import pm.gnosis.heimdall.StandardToken
-import pm.gnosis.heimdall.data.db.GnosisAuthenticatorDb
+import pm.gnosis.heimdall.data.db.ApplicationDb
 import pm.gnosis.heimdall.data.db.daos.DescriptionsDao
 import pm.gnosis.heimdall.data.remote.EthereumJsonRpcRepository
 import pm.gnosis.heimdall.data.remote.IpfsApi
@@ -34,7 +34,7 @@ class SimpleTransactionDetailsRepositoryTest {
     lateinit var descriptionsDaoMock: DescriptionsDao
 
     @Mock
-    lateinit var gnosisAuthenticatorDbMock: GnosisAuthenticatorDb
+    lateinit var appDbMock: ApplicationDb
 
     @Mock
     lateinit var ipfsApiMock: IpfsApi
@@ -43,8 +43,8 @@ class SimpleTransactionDetailsRepositoryTest {
 
     @Before
     fun setUp() {
-        given(gnosisAuthenticatorDbMock.descriptionsDao()).willReturn(descriptionsDaoMock)
-        repository = SimpleTransactionDetailsRepository(gnosisAuthenticatorDbMock)
+        given(appDbMock.descriptionsDao()).willReturn(descriptionsDaoMock)
+        repository = SimpleTransactionDetailsRepository(appDbMock)
     }
 
     private fun testLoadTransactionType(transaction: Transaction, expectedType: TransactionType) {

--- a/heimdall-common/src/main/java/pm/gnosis/heimdall/common/utils/ObservableUtils.kt
+++ b/heimdall-common/src/main/java/pm/gnosis/heimdall/common/utils/ObservableUtils.kt
@@ -51,6 +51,14 @@ fun <K, D> MutableMap<K, Observable<D>>.getSharedObservable(key: K, source: Obse
                     .autoConnect()
         })
 
+fun <D, O> Observable<Result<D>>.flatMapResult(
+        mapper: (D) -> Single<Result<O>>,
+        errorMapper: ((Throwable) -> Single<Result<O>>)? = null
+): Observable<Result<O>> =
+        flatMapSingle {
+            it.mapSingle(mapper, errorMapper)
+        }
+
 sealed class Result<out D> {
     fun handle(dataFun: ((D) -> Unit)?, errorFun: ((Throwable) -> Unit)?) {
         when (this) {


### PR DESCRIPTION
Closes WA-133 and WA-137.

Changes proposed in this pull request:
- Move request signature via push button from dialog to activity
- Fab on safe details opens scan transaction screen
- Fix create add owner transaction screen
- Renamed application database classes/files (this needs a reset of the app)

@gnosis/mobile-devs
