### PR TITLE
#155: Add travis badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Heimdall Android
+# Heimdall Android [![Build Status](https://travis-ci.org/gnosis/heimdall-android.svg?branch=master)](https://travis-ci.org/gnosis/heimdall-android)
 
 **WARNING: Under development. Don't use the application with real funds! Application right now targets the Rinkeby test network. Switching to mainnet (or any other ethereum network) can be done by the user but it's its responsibility in doing so.**
 


### PR DESCRIPTION
Closes #155 .

Changes proposed in this pull request:
- There was no build status indicator in the README. This will add a travis build status badge to it.


@gnosis/mobile-devs
