### PR TITLE
Remove unnecessary information from ci scripts

### DIFF
--- a/ci/notify_slack.sh
+++ b/ci/notify_slack.sh
@@ -2,9 +2,11 @@
 # fail if any commands fails
 set -e
 
+[[ -z "${SLACK_WEBHOOK}" ]] && exit 0
+
 repo_url="$(git config --get remote.origin.url)"
 release_path="/releases/tag/${TRAVIS_TAG}"
 release_url="${repo_url/.git/$release_path}"
 curl -X POST -H 'Content-type: application/json' \
 --data "{\"text\":\"<${release_url}|Version ${APP_VERSION_NAME}> for ${TRAVIS_REPO_SLUG} is out!\"}" \
-https://hooks.slack.com/services/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
+$SLACK_WEBHOOK

--- a/ci/prepare_env.sh
+++ b/ci/prepare_env.sh
@@ -2,17 +2,9 @@
 # fail if any commands fails
 set -e
 
-git tag
-
 # write your script here
 export APP_VERSION_CODE=$TRAVIS_BUILD_NUMBER
 # strip the first char as that should always be "v" (as tags should be in the format "vX.X.X")
 description="$(git describe --tags --always)"
 export APP_VERSION_NAME=${description:1}
 export APP_RELEASE_NOTES=$TRAVIS_COMMIT_MESSAGE
-
-echo $APP_VERSION_NAME
-echo $APP_RELEASE_NOTES
-
-echo "apiSecret=$FABRIC_API_SECRET" > app/fabric.properties
-echo "apiKey=$FABRIC_API_KEY" >> app/fabric.properties


### PR DESCRIPTION
Changes proposed in this pull request:
- Buildscript included unnecessary `echo` statements and a hard coded slack url. These have been removed

@gnosis/mobile-devs
