### PR TITLE
WA-285: Fix issues for internal test

### DIFF
--- a/app/src/main/java/pm/gnosis/heimdall/ui/onboarding/password/PasswordConfirmActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/onboarding/password/PasswordConfirmActivity.kt
@@ -3,6 +3,7 @@ package pm.gnosis.heimdall.ui.onboarding.password
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.inputmethod.EditorInfo
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.widget.textChanges
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -35,11 +36,20 @@ class PasswordConfirmActivity : SecuredBaseActivity() {
         super.onCreate(savedInstanceState)
         inject()
         setContentView(R.layout.layout_password_confirm)
-        layout_password_confirm_password.disableAccessibility()
 
         intent.getByteArrayExtra(EXTRA_PASSWORD_HASH)?.let { passwordHash = it } ?: run {
             Timber.e("PasswordConfirmActivity: Password is null")
             finish()
+        }
+
+        layout_password_confirm_password.disableAccessibility()
+        layout_password_confirm_password.requestFocus()
+        layout_password_confirm_password.setOnEditorActionListener { _, actionId, _ ->
+            when (actionId) {
+                EditorInfo.IME_ACTION_DONE, EditorInfo.IME_NULL ->
+                    layout_password_confirm_next.performClick()
+            }
+            true
         }
     }
 

--- a/app/src/main/java/pm/gnosis/heimdall/ui/onboarding/password/PasswordSetupActivity.kt
+++ b/app/src/main/java/pm/gnosis/heimdall/ui/onboarding/password/PasswordSetupActivity.kt
@@ -3,6 +3,7 @@ package pm.gnosis.heimdall.ui.onboarding.password
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.inputmethod.EditorInfo
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.widget.textChanges
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -33,6 +34,14 @@ class PasswordSetupActivity : SecuredBaseActivity() {
         setContentView(R.layout.layout_password_setup)
 
         layout_password_setup_password.disableAccessibility()
+        layout_password_setup_password.requestFocus()
+        layout_password_setup_password.setOnEditorActionListener { _, actionId, _ ->
+            when (actionId) {
+                EditorInfo.IME_ACTION_DONE, EditorInfo.IME_NULL ->
+                    layout_password_setup_next.performClick()
+            }
+            true
+        }
     }
 
     override fun onWindowObscured() {


### PR DESCRIPTION
Changes proposed in this pull request:
• WA-290: An error message should be shown to the user when something went wrong when clicking the deploy with external wallet button
• WA-291: Disable external wallet button while deploy is in progress
• WA-292: Enable password screen progression with softkeyboard

@gnosis/mobile-devs
